### PR TITLE
Upsert a Consumption to DB

### DIFF
--- a/example.py
+++ b/example.py
@@ -44,16 +44,17 @@ def History_tester():
     #history.dump_history()
     history.get_consumption_hourly()
 
-    insert_example = {"cups" : "ES0031300798436013HSx0F", "consumption_real" : 550, "consumption_proposal" : 179, "hour" : datetime(2016,03,01,01,00) }
+    insert_example = {"cups": "ES0031300798436013HSx0F",
+                      "consumption_real": 550,
+                      "consumption_proposal": 179,
+                      "hour": datetime(2016, 03, 01, 01, 00)}
 
     history.upsert_consumption(values=insert_example)
-
 
 
 def Sampledata_tester():
     dades = Mongo(user="orakwlum", db="orakwlum")
     dades.test_data(drop=True)
-
 
 #Sampledata_tester()
 

--- a/example.py
+++ b/example.py
@@ -44,6 +44,11 @@ def History_tester():
     #history.dump_history()
     history.get_consumption_hourly()
 
+    insert_example = {"cups" : "ES0031300798436013HSx0F", "consumption_real" : 223, "consumption_proposal" : 179, "hour" : datetime(2016,03,01,01,00) }
+
+    history.upsert_consumption(values=insert_example)
+
+
 
 def Sampledata_tester():
     dades = Mongo(user="orakwlum", db="orakwlum")

--- a/example.py
+++ b/example.py
@@ -36,14 +36,22 @@ def Datasource_tester():
 
 
 def History_tester():
-    date_start = datetime(2016, 3, 15)
-    date_end = datetime(2016, 3, 16)
+    date_start = datetime(2016, 3, 01)
+    date_end = datetime(2016, 3, 3)
 
     history = History(dini=date_start, dfi=date_end)
 
-    history.dump_history()
+    #history.dump_history()
+    history.get_consumption_hourly()
 
 
-logging.basicConfig(level=logging.DEBUG)
+def Sampledata_tester():
+    dades = Mongo(user="orakwlum", db="orakwlum")
+    dades.test_data(drop=True)
+
+
+#Sampledata_tester()
+
+logging.basicConfig(level=logging.INFO)
 
 History_tester()

--- a/example.py
+++ b/example.py
@@ -44,7 +44,7 @@ def History_tester():
     #history.dump_history()
     history.get_consumption_hourly()
 
-    insert_example = {"cups" : "ES0031300798436013HSx0F", "consumption_real" : 223, "consumption_proposal" : 179, "hour" : datetime(2016,03,01,01,00) }
+    insert_example = {"cups" : "ES0031300798436013HSx0F", "consumption_real" : 550, "consumption_proposal" : 179, "hour" : datetime(2016,03,01,01,00) }
 
     history.upsert_consumption(values=insert_example)
 

--- a/example_stdout.txt
+++ b/example_stdout.txt
@@ -1,514 +1,61 @@
 INFO:orakwlum.consumption.consumption:Creating new History
-DEBUG:orakwlum.consumption.consumption:  between 2016-03-15 00:00:00 - 2016-03-16 00:00:00
-DEBUG:orakwlum.consumption.consumption:  filtering for cups: None
 INFO:orakwlum.consumption.consumption:Loading History from datasource
 INFO:orakwlum.datasource.datasource:Establishing new Mongo datasource at 'mongodb://localhost:27017/'
 INFO:orakwlum.consumption.consumption:Filtering datasource by dates
-DEBUG:orakwlum.datasource.datasource:Date by hour expression {'hour': {'$lte': datetime.datetime(2016, 3, 16, 0, 0), '$gte': datetime.datetime(2016, 3, 15, 0, 0)}}
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 00:00:00. Real: 7, estimated: 8
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 00:00:00. Real: 61, estimated: 22
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 00:00:00. Real: 50, estimated: 84
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 00:00:00. Real: 40, estimated: 9
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 00:00:00. Real: 59, estimated: 13
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 01:00:00. Real: 20, estimated: 16
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 01:00:00. Real: 7, estimated: 94
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 01:00:00. Real: 18, estimated: 12
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 01:00:00. Real: 99, estimated: 49
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 01:00:00. Real: 79, estimated: 56
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 02:00:00. Real: 95, estimated: 68
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 02:00:00. Real: 16, estimated: 46
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 02:00:00. Real: 9, estimated: 14
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 02:00:00. Real: 79, estimated: 48
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 02:00:00. Real: 2, estimated: 62
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 03:00:00. Real: 68, estimated: 26
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 03:00:00. Real: 21, estimated: 88
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 03:00:00. Real: 34, estimated: 81
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 03:00:00. Real: 42, estimated: 75
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 03:00:00. Real: 22, estimated: 41
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 04:00:00. Real: 92, estimated: 49
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 04:00:00. Real: 42, estimated: 28
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 04:00:00. Real: 35, estimated: 56
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 04:00:00. Real: 43, estimated: 3
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 04:00:00. Real: 26, estimated: 8
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 05:00:00. Real: 29, estimated: 47
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 05:00:00. Real: 51, estimated: 38
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 05:00:00. Real: 77, estimated: 68
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 05:00:00. Real: 49, estimated: 93
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 05:00:00. Real: 56, estimated: 9
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 06:00:00. Real: 63, estimated: 7
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 06:00:00. Real: 59, estimated: 6
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 06:00:00. Real: 100, estimated: 10
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 06:00:00. Real: 68, estimated: 72
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 06:00:00. Real: 89, estimated: 1
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 07:00:00. Real: 19, estimated: 31
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 07:00:00. Real: 77, estimated: 14
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 07:00:00. Real: 1, estimated: 67
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 07:00:00. Real: 47, estimated: 59
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 07:00:00. Real: 41, estimated: 0
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 08:00:00. Real: 100, estimated: 81
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 08:00:00. Real: 27, estimated: 14
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 08:00:00. Real: 16, estimated: 32
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 08:00:00. Real: 35, estimated: 85
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 08:00:00. Real: 19, estimated: 9
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 09:00:00. Real: 100, estimated: 99
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 09:00:00. Real: 32, estimated: 0
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 09:00:00. Real: 39, estimated: 77
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 09:00:00. Real: 9, estimated: 29
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 09:00:00. Real: 93, estimated: 5
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 10:00:00. Real: 51, estimated: 67
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 10:00:00. Real: 55, estimated: 47
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 10:00:00. Real: 55, estimated: 10
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 10:00:00. Real: 1, estimated: 30
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 10:00:00. Real: 41, estimated: 51
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 11:00:00. Real: 5, estimated: 38
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 11:00:00. Real: 18, estimated: 58
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 11:00:00. Real: 28, estimated: 83
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 11:00:00. Real: 42, estimated: 86
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 11:00:00. Real: 67, estimated: 87
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 12:00:00. Real: 52, estimated: 44
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 12:00:00. Real: 96, estimated: 28
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 12:00:00. Real: 82, estimated: 82
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 12:00:00. Real: 62, estimated: 33
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 12:00:00. Real: 49, estimated: 28
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 13:00:00. Real: 24, estimated: 45
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 13:00:00. Real: 68, estimated: 54
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 13:00:00. Real: 95, estimated: 11
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 13:00:00. Real: 0, estimated: 13
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 13:00:00. Real: 40, estimated: 8
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 14:00:00. Real: 87, estimated: 49
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 14:00:00. Real: 12, estimated: 34
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 14:00:00. Real: 43, estimated: 57
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 14:00:00. Real: 100, estimated: 82
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 14:00:00. Real: 53, estimated: 55
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 15:00:00. Real: 58, estimated: 69
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 15:00:00. Real: 86, estimated: 49
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 15:00:00. Real: 74, estimated: 48
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 15:00:00. Real: 97, estimated: 47
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 15:00:00. Real: 3, estimated: 14
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 16:00:00. Real: 38, estimated: 70
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 16:00:00. Real: 88, estimated: 33
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 16:00:00. Real: 94, estimated: 96
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 16:00:00. Real: 50, estimated: 82
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 16:00:00. Real: 29, estimated: 60
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 17:00:00. Real: 40, estimated: 28
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 17:00:00. Real: 57, estimated: 99
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 17:00:00. Real: 54, estimated: 34
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 17:00:00. Real: 34, estimated: 78
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 17:00:00. Real: 10, estimated: 80
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 18:00:00. Real: 25, estimated: 6
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 18:00:00. Real: 11, estimated: 8
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 18:00:00. Real: 6, estimated: 17
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 18:00:00. Real: 52, estimated: 65
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 18:00:00. Real: 4, estimated: 48
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 19:00:00. Real: 54, estimated: 99
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 19:00:00. Real: 97, estimated: 16
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 19:00:00. Real: 63, estimated: 83
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 19:00:00. Real: 15, estimated: 61
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 19:00:00. Real: 12, estimated: 13
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 20:00:00. Real: 5, estimated: 88
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 20:00:00. Real: 19, estimated: 71
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 20:00:00. Real: 94, estimated: 14
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 20:00:00. Real: 1, estimated: 33
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 20:00:00. Real: 23, estimated: 29
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 21:00:00. Real: 88, estimated: 55
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 21:00:00. Real: 16, estimated: 58
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 21:00:00. Real: 45, estimated: 47
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 21:00:00. Real: 62, estimated: 82
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 21:00:00. Real: 67, estimated: 52
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 22:00:00. Real: 12, estimated: 33
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 22:00:00. Real: 43, estimated: 19
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 22:00:00. Real: 3, estimated: 42
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 22:00:00. Real: 84, estimated: 9
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 22:00:00. Real: 42, estimated: 40
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-15 23:00:00. Real: 9, estimated: 63
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-15 23:00:00. Real: 64, estimated: 83
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-15 23:00:00. Real: 1, estimated: 21
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-15 23:00:00. Real: 53, estimated: 82
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-15 23:00:00. Real: 38, estimated: 41
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300629986007HP0F at 2016-03-16 00:00:00. Real: 36, estimated: 78
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406174543003VH0F at 2016-03-16 00:00:00. Real: 9, estimated: 71
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031405989553003MF0F at 2016-03-16 00:00:00. Real: 17, estimated: 67
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031406213600001NA0F at 2016-03-16 00:00:00. Real: 41, estimated: 20
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
-INFO:orakwlum.consumption.consumption:Creating new consumption
-DEBUG:orakwlum.consumption.consumption:  for ES0031300808670001QS0F at 2016-03-16 00:00:00. Real: 8, estimated: 90
-DEBUG:orakwlum.consumption.consumption:  static data: prov: None, ZIP: None, Tariff: None, voltage: None, PoM: None, Distr: None, Time Discrimination: None
 INFO:orakwlum.datasource.datasource:Aggregating by 'cups'
-DEBUG:orakwlum.datasource.datasource:Aggregating using expression: '[{'$group': {'_id': '$cups'}}]'
-DEBUG:orakwlum.datasource.datasource: - {u'_id': u'ES0031300808670001QS0F'}
-DEBUG:orakwlum.datasource.datasource: - {u'_id': u'ES0031406213600001NA0F'}
-DEBUG:orakwlum.datasource.datasource: - {u'_id': u'ES0031405989553003MF0F'}
-DEBUG:orakwlum.datasource.datasource: - {u'_id': u'ES0031406174543003VH0F'}
-DEBUG:orakwlum.datasource.datasource: - {u'_id': u'ES0031300629986007HP0F'}
-  [2016-03-15 00:00:00] ES0031300629986007HP0F: 7kw / 8kw
-  [2016-03-15 00:00:00] ES0031406174543003VH0F: 61kw / 22kw
-  [2016-03-15 00:00:00] ES0031405989553003MF0F: 50kw / 84kw
-  [2016-03-15 00:00:00] ES0031406213600001NA0F: 40kw / 9kw
-  [2016-03-15 00:00:00] ES0031300808670001QS0F: 59kw / 13kw
-  [2016-03-15 01:00:00] ES0031300629986007HP0F: 20kw / 16kw
-  [2016-03-15 01:00:00] ES0031406174543003VH0F: 7kw / 94kw
-  [2016-03-15 01:00:00] ES0031405989553003MF0F: 18kw / 12kw
-  [2016-03-15 01:00:00] ES0031406213600001NA0F: 99kw / 49kw
-  [2016-03-15 01:00:00] ES0031300808670001QS0F: 79kw / 56kw
-  [2016-03-15 02:00:00] ES0031300629986007HP0F: 95kw / 68kw
-  [2016-03-15 02:00:00] ES0031406174543003VH0F: 16kw / 46kw
-  [2016-03-15 02:00:00] ES0031405989553003MF0F: 9kw / 14kw
-  [2016-03-15 02:00:00] ES0031406213600001NA0F: 79kw / 48kw
-  [2016-03-15 02:00:00] ES0031300808670001QS0F: 2kw / 62kw
-  [2016-03-15 03:00:00] ES0031300629986007HP0F: 68kw / 26kw
-  [2016-03-15 03:00:00] ES0031406174543003VH0F: 21kw / 88kw
-  [2016-03-15 03:00:00] ES0031405989553003MF0F: 34kw / 81kw
-  [2016-03-15 03:00:00] ES0031406213600001NA0F: 42kw / 75kw
-  [2016-03-15 03:00:00] ES0031300808670001QS0F: 22kw / 41kw
-  [2016-03-15 04:00:00] ES0031300629986007HP0F: 92kw / 49kw
-  [2016-03-15 04:00:00] ES0031406174543003VH0F: 42kw / 28kw
-  [2016-03-15 04:00:00] ES0031405989553003MF0F: 35kw / 56kw
-  [2016-03-15 04:00:00] ES0031406213600001NA0F: 43kw / 3kw
-  [2016-03-15 04:00:00] ES0031300808670001QS0F: 26kw / 8kw
-  [2016-03-15 05:00:00] ES0031300629986007HP0F: 29kw / 47kw
-  [2016-03-15 05:00:00] ES0031406174543003VH0F: 51kw / 38kw
-  [2016-03-15 05:00:00] ES0031405989553003MF0F: 77kw / 68kw
-  [2016-03-15 05:00:00] ES0031406213600001NA0F: 49kw / 93kw
-  [2016-03-15 05:00:00] ES0031300808670001QS0F: 56kw / 9kw
-  [2016-03-15 06:00:00] ES0031300629986007HP0F: 63kw / 7kw
-  [2016-03-15 06:00:00] ES0031406174543003VH0F: 59kw / 6kw
-  [2016-03-15 06:00:00] ES0031405989553003MF0F: 100kw / 10kw
-  [2016-03-15 06:00:00] ES0031406213600001NA0F: 68kw / 72kw
-  [2016-03-15 06:00:00] ES0031300808670001QS0F: 89kw / 1kw
-  [2016-03-15 07:00:00] ES0031300629986007HP0F: 19kw / 31kw
-  [2016-03-15 07:00:00] ES0031406174543003VH0F: 77kw / 14kw
-  [2016-03-15 07:00:00] ES0031405989553003MF0F: 1kw / 67kw
-  [2016-03-15 07:00:00] ES0031406213600001NA0F: 47kw / 59kw
-  [2016-03-15 07:00:00] ES0031300808670001QS0F: 41kw / 0kw
-  [2016-03-15 08:00:00] ES0031300629986007HP0F: 100kw / 81kw
-  [2016-03-15 08:00:00] ES0031406174543003VH0F: 27kw / 14kw
-  [2016-03-15 08:00:00] ES0031405989553003MF0F: 16kw / 32kw
-  [2016-03-15 08:00:00] ES0031406213600001NA0F: 35kw / 85kw
-  [2016-03-15 08:00:00] ES0031300808670001QS0F: 19kw / 9kw
-  [2016-03-15 09:00:00] ES0031300629986007HP0F: 100kw / 99kw
-  [2016-03-15 09:00:00] ES0031406174543003VH0F: 32kw / 0kw
-  [2016-03-15 09:00:00] ES0031405989553003MF0F: 39kw / 77kw
-  [2016-03-15 09:00:00] ES0031406213600001NA0F: 9kw / 29kw
-  [2016-03-15 09:00:00] ES0031300808670001QS0F: 93kw / 5kw
-  [2016-03-15 10:00:00] ES0031300629986007HP0F: 51kw / 67kw
-  [2016-03-15 10:00:00] ES0031406174543003VH0F: 55kw / 47kw
-  [2016-03-15 10:00:00] ES0031405989553003MF0F: 55kw / 10kw
-  [2016-03-15 10:00:00] ES0031406213600001NA0F: 1kw / 30kw
-  [2016-03-15 10:00:00] ES0031300808670001QS0F: 41kw / 51kw
-  [2016-03-15 11:00:00] ES0031300629986007HP0F: 5kw / 38kw
-  [2016-03-15 11:00:00] ES0031406174543003VH0F: 18kw / 58kw
-  [2016-03-15 11:00:00] ES0031405989553003MF0F: 28kw / 83kw
-  [2016-03-15 11:00:00] ES0031406213600001NA0F: 42kw / 86kw
-  [2016-03-15 11:00:00] ES0031300808670001QS0F: 67kw / 87kw
-  [2016-03-15 12:00:00] ES0031300629986007HP0F: 52kw / 44kw
-  [2016-03-15 12:00:00] ES0031406174543003VH0F: 96kw / 28kw
-  [2016-03-15 12:00:00] ES0031405989553003MF0F: 82kw / 82kw
-  [2016-03-15 12:00:00] ES0031406213600001NA0F: 62kw / 33kw
-  [2016-03-15 12:00:00] ES0031300808670001QS0F: 49kw / 28kw
-  [2016-03-15 13:00:00] ES0031300629986007HP0F: 24kw / 45kw
-  [2016-03-15 13:00:00] ES0031406174543003VH0F: 68kw / 54kw
-  [2016-03-15 13:00:00] ES0031405989553003MF0F: 95kw / 11kw
-  [2016-03-15 13:00:00] ES0031406213600001NA0F: 0kw / 13kw
-  [2016-03-15 13:00:00] ES0031300808670001QS0F: 40kw / 8kw
-  [2016-03-15 14:00:00] ES0031300629986007HP0F: 87kw / 49kw
-  [2016-03-15 14:00:00] ES0031406174543003VH0F: 12kw / 34kw
-  [2016-03-15 14:00:00] ES0031405989553003MF0F: 43kw / 57kw
-  [2016-03-15 14:00:00] ES0031406213600001NA0F: 100kw / 82kw
-  [2016-03-15 14:00:00] ES0031300808670001QS0F: 53kw / 55kw
-  [2016-03-15 15:00:00] ES0031300629986007HP0F: 58kw / 69kw
-  [2016-03-15 15:00:00] ES0031406174543003VH0F: 86kw / 49kw
-  [2016-03-15 15:00:00] ES0031405989553003MF0F: 74kw / 48kw
-  [2016-03-15 15:00:00] ES0031406213600001NA0F: 97kw / 47kw
-  [2016-03-15 15:00:00] ES0031300808670001QS0F: 3kw / 14kw
-  [2016-03-15 16:00:00] ES0031300629986007HP0F: 38kw / 70kw
-  [2016-03-15 16:00:00] ES0031406174543003VH0F: 88kw / 33kw
-  [2016-03-15 16:00:00] ES0031405989553003MF0F: 94kw / 96kw
-  [2016-03-15 16:00:00] ES0031406213600001NA0F: 50kw / 82kw
-  [2016-03-15 16:00:00] ES0031300808670001QS0F: 29kw / 60kw
-  [2016-03-15 17:00:00] ES0031300629986007HP0F: 40kw / 28kw
-  [2016-03-15 17:00:00] ES0031406174543003VH0F: 57kw / 99kw
-  [2016-03-15 17:00:00] ES0031405989553003MF0F: 54kw / 34kw
-  [2016-03-15 17:00:00] ES0031406213600001NA0F: 34kw / 78kw
-  [2016-03-15 17:00:00] ES0031300808670001QS0F: 10kw / 80kw
-  [2016-03-15 18:00:00] ES0031300629986007HP0F: 25kw / 6kw
-  [2016-03-15 18:00:00] ES0031406174543003VH0F: 11kw / 8kw
-  [2016-03-15 18:00:00] ES0031405989553003MF0F: 6kw / 17kw
-  [2016-03-15 18:00:00] ES0031406213600001NA0F: 52kw / 65kw
-  [2016-03-15 18:00:00] ES0031300808670001QS0F: 4kw / 48kw
-  [2016-03-15 19:00:00] ES0031300629986007HP0F: 54kw / 99kw
-  [2016-03-15 19:00:00] ES0031406174543003VH0F: 97kw / 16kw
-  [2016-03-15 19:00:00] ES0031405989553003MF0F: 63kw / 83kw
-  [2016-03-15 19:00:00] ES0031406213600001NA0F: 15kw / 61kw
-  [2016-03-15 19:00:00] ES0031300808670001QS0F: 12kw / 13kw
-  [2016-03-15 20:00:00] ES0031300629986007HP0F: 5kw / 88kw
-  [2016-03-15 20:00:00] ES0031406174543003VH0F: 19kw / 71kw
-  [2016-03-15 20:00:00] ES0031405989553003MF0F: 94kw / 14kw
-  [2016-03-15 20:00:00] ES0031406213600001NA0F: 1kw / 33kw
-  [2016-03-15 20:00:00] ES0031300808670001QS0F: 23kw / 29kw
-  [2016-03-15 21:00:00] ES0031300629986007HP0F: 88kw / 55kw
-  [2016-03-15 21:00:00] ES0031406174543003VH0F: 16kw / 58kw
-  [2016-03-15 21:00:00] ES0031405989553003MF0F: 45kw / 47kw
-  [2016-03-15 21:00:00] ES0031406213600001NA0F: 62kw / 82kw
-  [2016-03-15 21:00:00] ES0031300808670001QS0F: 67kw / 52kw
-  [2016-03-15 22:00:00] ES0031300629986007HP0F: 12kw / 33kw
-  [2016-03-15 22:00:00] ES0031406174543003VH0F: 43kw / 19kw
-  [2016-03-15 22:00:00] ES0031405989553003MF0F: 3kw / 42kw
-  [2016-03-15 22:00:00] ES0031406213600001NA0F: 84kw / 9kw
-  [2016-03-15 22:00:00] ES0031300808670001QS0F: 42kw / 40kw
-  [2016-03-15 23:00:00] ES0031300629986007HP0F: 9kw / 63kw
-  [2016-03-15 23:00:00] ES0031406174543003VH0F: 64kw / 83kw
-  [2016-03-15 23:00:00] ES0031405989553003MF0F: 1kw / 21kw
-  [2016-03-15 23:00:00] ES0031406213600001NA0F: 53kw / 82kw
-  [2016-03-15 23:00:00] ES0031300808670001QS0F: 38kw / 41kw
-  [2016-03-16 00:00:00] ES0031300629986007HP0F: 36kw / 78kw
-  [2016-03-16 00:00:00] ES0031406174543003VH0F: 9kw / 71kw
-  [2016-03-16 00:00:00] ES0031405989553003MF0F: 17kw / 67kw
-  [2016-03-16 00:00:00] ES0031406213600001NA0F: 41kw / 20kw
-  [2016-03-16 00:00:00] ES0031300808670001QS0F: 8kw / 90kw
+INFO:orakwlum.consumption.consumption:Get consumption hourly by dates
+INFO:orakwlum.consumption.consumption:Reaching consumption by hour, between [datetime.datetime(2016, 3, 1, 0, 0), datetime.datetime(2016, 3, 3, 0, 0)] and sort by [['hour', 1]]
+INFO:orakwlum.datasource.datasource: Using expression:
+[{'$match': {'hour': {'$lte': datetime.datetime(2016, 3, 3, 0, 0), '$gte': datetime.datetime(2016, 3, 1, 0, 0)}}}, {'$group': {'_id': '$hour', 'sum_consumption_real': {'$sum': '$consumption_real'}, 'sum_consumption_proposal': {'$sum': '$consumption_proposal'}}}, {'$sort': {'_id': 1}}]
+INFO:orakwlum.datasource.datasource:Aggregating by 'hour' and adding by '['consumption_real', 'consumption_proposal']'
+INFO:orakwlum.datasource.datasource:Upserting {'consumption_real': 550, 'consumption_proposal': 179} for {'cups': 'ES0031300798436013HSx0F', 'hour': datetime.datetime(2016, 3, 1, 1, 0)} on test_data
+
+  2016-03-01 00:00:00: 1284kw / 1381kw
+  2016-03-01 01:00:00: 2169kw / 1424kw
+  2016-03-01 02:00:00: 1358kw / 1030kw
+  2016-03-01 03:00:00: 1180kw / 1242kw
+  2016-03-01 04:00:00: 1331kw / 1353kw
+  2016-03-01 05:00:00: 1110kw / 1146kw
+  2016-03-01 06:00:00: 1386kw / 1244kw
+  2016-03-01 07:00:00: 1406kw / 1378kw
+  2016-03-01 08:00:00: 1139kw / 1308kw
+  2016-03-01 09:00:00: 1311kw / 1289kw
+  2016-03-01 10:00:00: 1247kw / 1206kw
+  2016-03-01 11:00:00: 1313kw / 1503kw
+  2016-03-01 12:00:00: 1251kw / 1121kw
+  2016-03-01 13:00:00: 1400kw / 1409kw
+  2016-03-01 14:00:00: 1334kw / 1223kw
+  2016-03-01 15:00:00: 1221kw / 1408kw
+  2016-03-01 16:00:00: 1151kw / 1518kw
+  2016-03-01 17:00:00: 1374kw / 1356kw
+  2016-03-01 18:00:00: 1401kw / 1357kw
+  2016-03-01 19:00:00: 1377kw / 1173kw
+  2016-03-01 20:00:00: 1265kw / 1482kw
+  2016-03-01 21:00:00: 1203kw / 1268kw
+  2016-03-01 22:00:00: 1139kw / 991kw
+  2016-03-01 23:00:00: 1221kw / 1066kw
+  2016-03-02 00:00:00: 1120kw / 1100kw
+  2016-03-02 01:00:00: 1364kw / 1298kw
+  2016-03-02 02:00:00: 1065kw / 1060kw
+  2016-03-02 03:00:00: 1335kw / 1250kw
+  2016-03-02 04:00:00: 1340kw / 1582kw
+  2016-03-02 05:00:00: 1027kw / 1070kw
+  2016-03-02 06:00:00: 1332kw / 1361kw
+  2016-03-02 07:00:00: 1032kw / 1067kw
+  2016-03-02 08:00:00: 1324kw / 1218kw
+  2016-03-02 09:00:00: 1339kw / 1310kw
+  2016-03-02 10:00:00: 1326kw / 1049kw
+  2016-03-02 11:00:00: 1451kw / 1269kw
+  2016-03-02 12:00:00: 1221kw / 1353kw
+  2016-03-02 13:00:00: 1063kw / 1119kw
+  2016-03-02 14:00:00: 1094kw / 1304kw
+  2016-03-02 15:00:00: 1299kw / 1433kw
+  2016-03-02 16:00:00: 1402kw / 1213kw
+  2016-03-02 17:00:00: 1291kw / 1376kw
+  2016-03-02 18:00:00: 1331kw / 1271kw
+  2016-03-02 19:00:00: 1034kw / 1172kw
+  2016-03-02 20:00:00: 1252kw / 1244kw
+  2016-03-02 21:00:00: 1301kw / 1488kw
+  2016-03-02 22:00:00: 1206kw / 1193kw
+  2016-03-02 23:00:00: 1353kw / 1107kw
+  2016-03-03 00:00:00: 1461kw / 1219kw

--- a/orakwlum/consumption/consumption.py
+++ b/orakwlum/consumption/consumption.py
@@ -141,24 +141,34 @@ class History(object):
         "PK" will be (cups, hour)
         """
 
+        key_fields = ["cups","hour"]
+        fields_to_upsert = ["consumption_real", "consumption_proposal"]
 
+        key = dict()
+        update = dict()
+
+        # Prepare the key and the values. Handles dict and Consumption objects
         if values and type(values) == dict:
-            assert values['cups'] and values['hour']
-            key = { "cups" : values['cups'], "hour": values['hour']}
-            assert values['consumption_real'] or values['consumption_proposal']
-            update = { "consumption_real": values['consumption_real'] , "consumption_proposal": values['consumption_proposal']  }
+            for key_field in key_fields:
+                assert values[key_field]
+                key[key_field] = values[key_field]
+                #key = { "cups" : values['cups'], "hour": values['hour']}
 
+            for field_to_upsert in fields_to_upsert:
+                assert values[field_to_upsert]
+                if values[field_to_upsert]:  #if None not update this field
+                    update[field_to_upsert] = values[field_to_upsert]
+
+        # todo RIP it and create save method on Consumption that calls JSON upsert if needed
         elif type(values) == Consumption:
             assert values.cups.number and values.hour
             key = { "cups" : values.cups.number, "hour": values.hour}
             assert values.consumption_proposal or values.consumption_real
             update = { "consumption_real": values.consumption_real , "consumption_proposal": values.consumption_proposal }
 
-        #values = {"cups" : "ES0031300798436013HSx0F", "consumption_real" : 123, "consumption_proposal" : 179, "hour" : datetime(2016,03,01,01,00) }
-
+        # Upsert it through datasource!
         self.dataset.upsert(key=key, what=update)
 
-        #self.dataset.
 
     def get_consumption_hourly(self):
         logger.info("Get consumption hourly by dates")

--- a/orakwlum/consumption/consumption.py
+++ b/orakwlum/consumption/consumption.py
@@ -127,6 +127,39 @@ class History(object):
             self.cups_list.append(cups['_id'])
 
 
+
+
+    # todo review upsert static data
+    def upsert_consumption (self, values):
+        """
+        Update or Insert a Consumption to DB
+
+        Consumption can be passed as a dict or as a Consumption object
+
+        Currently just upsert consumptions, future static data
+
+        "PK" will be (cups, hour)
+        """
+
+
+        if values and type(values) == dict:
+            assert values['cups'] and values['hour']
+            key = { "cups" : values['cups'], "hour": values['hour']}
+            assert values['consumption_real'] or values['consumption_proposal']
+            update = { "consumption_real": values['consumption_real'] , "consumption_proposal": values['consumption_proposal']  }
+
+        elif type(values) == Consumption:
+            assert values.cups.number and values.hour
+            key = { "cups" : values.cups.number, "hour": values.hour}
+            assert values.consumption_proposal or values.consumption_real
+            update = { "consumption_real": values.consumption_real , "consumption_proposal": values.consumption_proposal }
+
+        #values = {"cups" : "ES0031300798436013HSx0F", "consumption_real" : 123, "consumption_proposal" : 179, "hour" : datetime(2016,03,01,01,00) }
+
+        self.dataset.upsert(key=key, what=update)
+
+        #self.dataset.
+
     def get_consumption_hourly(self):
         logger.info("Get consumption hourly by dates")
 

--- a/orakwlum/datasource/datasource.py
+++ b/orakwlum/datasource/datasource.py
@@ -316,7 +316,7 @@ class Mongo(DataSource):
 
         dades.update(key, update, upsert=True)
 
-        logger.debug("Value post upserting: '{}'".format( list(dades.find(key)) ))
+        logger.info("Value post upserting: '{}'".format( list(dades.find(key)) ))
 
 
 

--- a/orakwlum/datasource/datasource.py
+++ b/orakwlum/datasource/datasource.py
@@ -243,6 +243,7 @@ class Mongo(DataSource):
 
         return self.aggregate(collection, expression)
 
+    # todo multiple aggregation and standarize other aggreg
     def aggregate_sum(
             self,
             field_to_agg="hour",
@@ -265,6 +266,7 @@ class Mongo(DataSource):
 
         # Set the match filter
         if fields_to_filter:
+            # todo validate filters
             #for filter in fields_to_filter:
             filter = self.set_filter(by_date=fields_to_filter)
             expression.append( { "$match": filter } )
@@ -290,3 +292,31 @@ class Mongo(DataSource):
             field_to_agg, fields_to_sum))
 
         return self.aggregate(collection, expression)
+
+
+    def upsert (self, key, what, collection="test_data"):
+        """
+        Insert or update if exist what using key
+
+            what: dictionary with all elements to upsert
+            key: restriction to update
+
+        """
+        if not what or type(what) is not dict:
+            print "Upsert failed, not correctly formatted values to insert/update :'{}'".format(what)
+            return
+
+        logger.info ("Upserting {} for {} on {}".format(what, key, collection))
+
+        update = { "$set": what}
+
+        dades = self.db[collection]
+
+        logger.debug("Value pre  upserting: '{}'".format( list(dades.find(key)) ))
+
+        dades.update(key, update, upsert=True)
+
+        logger.debug("Value post upserting: '{}'".format( list(dades.find(key)) ))
+
+
+

--- a/orakwlum/datasource/datasource.py
+++ b/orakwlum/datasource/datasource.py
@@ -125,8 +125,7 @@ class Mongo(DataSource):
         except:
             print "Error insering on '{}'".format(collection)
 
-
-    def set_filter (self,by_date=None, by_cups=None):
+    def set_filter(self, by_date=None, by_cups=None):
         """
         Return a filter expression based on date ranges or filtering by CUPS
         """
@@ -190,8 +189,7 @@ class Mongo(DataSource):
             if count:  #convert to  { .... , "count": {"$sum": 1} }
                 agg_exp['$group']["count_" + field] = {"$sum": 1}
             else:
-                agg_exp['$group']["sum_" + field] = {"$" + action:
-                                                        "$" + field}
+                agg_exp['$group']["sum_" + field] = {"$" + action: "$" + field}
 
         return agg_exp
 
@@ -269,22 +267,22 @@ class Mongo(DataSource):
             # todo validate filters
             #for filter in fields_to_filter:
             filter = self.set_filter(by_date=fields_to_filter)
-            expression.append( { "$match": filter } )
+            expression.append({"$match": filter})
 
         # Set the agroupation and SUMs
         group = {"$group": {"_id": "$" + field_to_agg, }}
         group = self.aggregate_action(group, "sum", fields_to_sum)
-        expression.append ( group)
+        expression.append(group)
 
         if fields_to_sort:
             #todo validate format of fields_to_sort
             for sort in fields_to_sort:
-                if field_to_agg == sort[0]:   #if field_to_aggregate is the same thant the sort, ensure that sort name is "_id"
+                if field_to_agg == sort[
+                        0]:  #if field_to_aggregate is the same thant the sort, ensure that sort name is "_id"
                     sort[0] = "_id"
-                expression.append ( { "$sort" : { sort[0] : sort[1]} }  )
+                expression.append({"$sort": {sort[0]: sort[1]}})
 
         #print "db.test_data.aggregate( " + str(expression) + ")"
-
 
         logger.info(" Using expression: \n{}".format(expression))
 
@@ -293,8 +291,7 @@ class Mongo(DataSource):
 
         return self.aggregate(collection, expression)
 
-
-    def upsert (self, key, what, collection="test_data"):
+    def upsert(self, key, what, collection="test_data"):
         """
         Insert or update if exist what using key
 
@@ -303,20 +300,20 @@ class Mongo(DataSource):
 
         """
         if not what or type(what) is not dict:
-            print "Upsert failed, not correctly formatted values to insert/update :'{}'".format(what)
+            print "Upsert failed, not correctly formatted values to insert/update :'{}'".format(
+                what)
             return
 
-        logger.info ("Upserting {} for {} on {}".format(what, key, collection))
+        logger.info("Upserting {} for {} on {}".format(what, key, collection))
 
-        update = { "$set": what}
+        update = {"$set": what}
 
         dades = self.db[collection]
 
-        logger.debug("Value pre  upserting: '{}'".format( list(dades.find(key)) ))
+        logger.debug("Val   ue pre  upserting: '{}'".format(list(dades.find(
+            key))))
 
         dades.update(key, update, upsert=True)
 
-        logger.info("Value post upserting: '{}'".format( list(dades.find(key)) ))
-
-
-
+        logger.debug("Value post upserting: '{}'".format(list(dades.find(
+            key))))

--- a/orakwlum/datasource/datasource.py
+++ b/orakwlum/datasource/datasource.py
@@ -74,12 +74,22 @@ class Mongo(DataSource):
             collection, self.db_connection_string))
 
         cups_list = ["ES0031300629986007HP0F", "ES0031406174543003VH0F",
-                     "ES0031405989553003MF0F", "ES0031406213600001NA0F",
+                     "ES0031300714101001PT0F", "ES0031406213600001NA0F",
+                     "ES0031406223927009YB0F", "ES0031406213354001BB0F",
+                     "ES0031405458897012HQ0F", "ES0031406058147001NR0F",
+                     "ES0031300798436013HS0F", "ES0031406223989001XH0F",
+                     "ES0031405534374002DE0F", "ES0031405879092008YP0F",
+                     "ES0031405567043016JC0F", "ES0031300002988011PK0F",
+                     "ES0031405667112006KN0F", "ES0031406057682003BV0F",
+                     "ES0031406213108001XL0F", "ES0031300814622002AF0F",
+                     "ES0031300828111030MH0F", "ES0031406229285001HS0F",
+                     "ES0031406216506001CE0F", "ES0031406270151013MH0F",
+                     "ES0031300826614001FJ0F", "ES0031406227364001DK0F",
                      "ES0031300808670001QS0F"]
         hour_start = 00
         hour_end = 24
-        day_start = 15
-        day_end = 17
+        day_start = 01
+        day_end = 31
         month = 03
         year = 2016
 
@@ -115,7 +125,11 @@ class Mongo(DataSource):
         except:
             print "Error insering on '{}'".format(collection)
 
-    def filter(self, by_date=None, by_cups=None, collection="test_data"):
+
+    def set_filter (self,by_date=None, by_cups=None):
+        """
+        Return a filter expression based on date ranges or filtering by CUPS
+        """
         if by_date:
             #validate [date_ini, date_fi] datetime
             exp = {"hour": {"$gte": by_date[0], "$lte": by_date[1]}}
@@ -124,6 +138,14 @@ class Mongo(DataSource):
         if by_cups:
             #validate cups
             pass
+
+        return exp
+
+    def filter(self, by_date=None, by_cups=None, collection="test_data"):
+        """
+        Return a filtered collection cursor
+        """
+        exp = self.set_filter(by_date, by_cups)
 
         data_filter = self.db[collection]
 
@@ -166,9 +188,9 @@ class Mongo(DataSource):
 
         for field in fields_to_operate:
             if count:  #convert to  { .... , "count": {"$sum": 1} }
-                agg_exp[0]['$group']["count_" + field] = {"$sum": 1}
+                agg_exp['$group']["count_" + field] = {"$sum": 1}
             else:
-                agg_exp[0]['$group']["sum_" + field] = {"$" + action:
+                agg_exp['$group']["sum_" + field] = {"$" + action:
                                                         "$" + field}
 
         return agg_exp
@@ -223,19 +245,46 @@ class Mongo(DataSource):
 
     def aggregate_sum(
             self,
-            field_to_agg="cups",
+            field_to_agg="hour",
             fields_to_sum=["consumption_real", "consumption_proposal"],
+            fields_to_filter=None,
+            fields_to_sort=None,
             collection="test_data"):
         """
         Aggregate a collection by field and extract the sum of field_to_sum
+
+        Filter the collection by fields_to_filter
+
+        Sort the aggregate result by fielts_to_sort
 
         Return a list of dicts:
             [ {'_id': 'FIELD', field_to_sum+"_TOTAL": COUNT}, ...]
         """
 
-        expression = [{"$group": {"_id": "$" + field_to_agg, }}]
+        expression = []
 
-        expression = self.aggregate_action(expression, "sum", fields_to_sum)
+        # Set the match filter
+        if fields_to_filter:
+            #for filter in fields_to_filter:
+            filter = self.set_filter(by_date=fields_to_filter)
+            expression.append( { "$match": filter } )
+
+        # Set the agroupation and SUMs
+        group = {"$group": {"_id": "$" + field_to_agg, }}
+        group = self.aggregate_action(group, "sum", fields_to_sum)
+        expression.append ( group)
+
+        if fields_to_sort:
+            #todo validate format of fields_to_sort
+            for sort in fields_to_sort:
+                if field_to_agg == sort[0]:   #if field_to_aggregate is the same thant the sort, ensure that sort name is "_id"
+                    sort[0] = "_id"
+                expression.append ( { "$sort" : { sort[0] : sort[1]} }  )
+
+        #print "db.test_data.aggregate( " + str(expression) + ")"
+
+
+        logger.info(" Using expression: \n{}".format(expression))
 
         logger.info("Aggregating by '{}' and adding by '{}'".format(
             field_to_agg, fields_to_sum))


### PR DESCRIPTION
**Update or Insert a Consumption to DB**
- Consumption can be passed as a dict or as a Consumption object
- Currently just upsert consumptions, future static data
- "PK" will be (cups, hour)
- Fields dynamically loaded for key and values to upsert


**Filter the collection by a range of dates**
- Aggregate by hours
- Sum the consumptions (real, proposal)
- Sort the result by hour ascendent

I.e. filtering hours between 2016/03/01 and 2016/03/03

date_start = datetime(2016, 3, 01)
date_end = datetime(2016, 3, 2)
history = History(dini=date_start, dfi=date_end)

will use the following exp to Mongo:
```
[
  {'$match': 
         {
           'hour': { 
                  '$lte': datetime.datetime(2016, 3, 3, 0, 0),
                  '$gte': datetime.datetime(2016, 3, 1, 0, 0)
           }
         }
  },

  {'$group':
         { 
           '_id': '$hour', 
           'sum_consumption_real': {'$sum': '$consumption_real'},
           'sum_consumption_proposal': {'$sum': '$consumption_proposal'}
         }
  },

  {'$sort': {'_id': 1}}
]
```