### PR TITLE
Import using parallel threats

### DIFF
--- a/example.py
+++ b/example.py
@@ -204,7 +204,7 @@ def Import_Massive(path_="/opt/srcs/f1/F101", type="F1", CPUs=4):
     try:
         pool.map(processer , ((fileF1, idx, max) for idx, fileF1 in enumerate(files)) )
     except Exception as e:
-        print "Thread error at processing '<{}> {}'".format( type(e), e.args )
+        print "Thread error at processing '<{}>'".format(e)
 
     pool.close()
     pool.join()

--- a/example.py
+++ b/example.py
@@ -149,9 +149,44 @@ def Import_testerLiteQ1():
     importer.process_consumptions()
 
 
-logging.basicConfig(level=logging.DEBUG)
+def process_file(args):
+    file, idx, max = args
+    mess ="{}/{} Procesing F1 '{}'".format(idx, max, file)
+    print mess
+    logging.info(mess)
+
+    importer = F1Importer(file, "import")
+    #print "Type: {}".format(importer.type)
+    #print "Count: {}".format(importer.invoices_count)
+    invoices = importer.invoices
+    importer.process_consumptions()
+    os.rename(file, file+"_done")
+
+
+
+from multiprocessing.dummy import Pool as ThreadPool
+import glob, os
+def Import_Q1():
+
+    os.chdir("/opt/srcs/abe/abe_f1_comer_706/2015-01-Mes/0706/")
+    files = glob.glob("*.xml")
+    max = len(files)
+
+    pool = ThreadPool(4)
+    #pool.map( process_file, files )
+    pool.map( process_file, ((file, idx, max) for idx, file in enumerate(files)) )
+
+    pool.close()
+    pool.join()
+
+    #for idx,file in enumerate(files):
+        #process_file(file)
+
+
+
+logging.basicConfig(level=logging.INFO)
 
 #Sampledata_tester()
 #Proposal_tester()
 
-Import_testerLiteQ1()
+Import_Q1()

--- a/orakwlum/datasource/mongo.py
+++ b/orakwlum/datasource/mongo.py
@@ -36,7 +36,7 @@ class Mongo(DataSource):
 
         self.db_connection_string = "mongodb://" + host + ":" + port + "/"
 
-        logger.info("Establishing new Mongo datasource at '{}'".format(
+        logger.debug("Establishing new Mongo datasource at '{}'".format(
             self.db_connection_string))
 
         try:
@@ -166,7 +166,7 @@ class Mongo(DataSource):
 
         data_filter = self.db[collection]
 
-        logger.info("Adding filter by {} to {}".format(exp, collection))
+        logger.debug("Adding filter by {} to {}".format(exp, collection))
 
         return data_filter.find(exp)
 
@@ -222,7 +222,7 @@ class Mongo(DataSource):
         """
         expression = [{"$group": {"_id": "$" + field, "count": {"$sum": 1}}}]
 
-        logger.info("Aggregating and counting by '{}'".format(field))
+        logger.debug("Aggregating and counting by '{}'".format(field))
 
         return self.aggregate(collection, expression)
 
@@ -235,7 +235,7 @@ class Mongo(DataSource):
         """
         expression = [{"$group": {"_id": "$" + field}}]
 
-        logger.info("Aggregating by '{}'".format(field))
+        logger.debug("Aggregating by '{}'".format(field))
 
         return self.aggregate(collection, expression)
 
@@ -256,7 +256,7 @@ class Mongo(DataSource):
         expression = self.aggregate_action(expression, "count",
                                            fields_to_count)
 
-        logger.info("Aggregating by '{}' and adding by '{}'".format(
+        logger.debug("Aggregating by '{}' and adding by '{}'".format(
             field_to_agg, field_to_agg))
 
         return self.aggregate(collection, expression)
@@ -351,9 +351,9 @@ class Mongo(DataSource):
 
         #print "db.test_data.aggregate( " + str(expression) + ")"
 
-        logger.info(" Using expression: \n{}".format(expression))
+        logger.debug(" Using expression: \n{}".format(expression))
 
-        logger.info(
+        logger.debug(
             "Aggregating by '{}', filtering by {} and adding by '{}'".format(
                 field_to_agg, fields_to_filter, fields_to_operate))
 
@@ -391,6 +391,6 @@ class Mongo(DataSource):
         """
         Drops a collection
         """
-        logger.info("Deleting collection '{}'".format(collection))
+        logger.debug("Deleting collection '{}'".format(collection))
 
         return self.db[collection].drop()

--- a/orakwlum/importer/F1Importer.py
+++ b/orakwlum/importer/F1Importer.py
@@ -64,7 +64,7 @@ class F1Importer(Import):
 
         # Get all FacturaATR invoices
         for factura_atr in invoices['FacturaATR']:
-            self.print_invoice_summary(factura_atr)
+            #self.print_invoice_summary(factura_atr)
             periods, consumption_total = factura_atr.get_info_activa()
 
             tariff_code = factura_atr.codi_tarifa
@@ -91,7 +91,7 @@ class F1Importer(Import):
 
                 # For each measure of the profile create a Consumption
                 for measure in estimation.measures:
-                    logger.info( "  [F1] Processing {} {} {}".format( factura_atr.cups, measure.date, measure.measure) )
+                    logger.debug( "  [F1] Processing {} {} {}".format( factura_atr.cups, measure.date, measure.measure) )
 
                     consumption_from_measure = Consumption(cups=factura_atr.cups,
                                                            hour=measure.date,

--- a/orakwlum/importer/importer.py
+++ b/orakwlum/importer/importer.py
@@ -70,7 +70,7 @@ class Import(object):
 
         # Finally, IMPORTER vs DATA    ## if the same priority override datasource (rectifications)
         if (importer_priority <= current_data_priority):
-            logger.info("Saving imported consumption to DB (priorities: '{} vs {}')".format(importer_priority, current_data_priority))
+            logger.debug("Saving imported consumption to DB (priorities: '{} vs {}')".format(importer_priority, current_data_priority))
             consumption_to_save.save(self.dataset, self.collection)
 
 

--- a/utils/importer.py
+++ b/utils/importer.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+__author__ = 'XaviTorello'
+
+from orakwlum.importer import *
+
+import logging, glob, os
+from multiprocessing.dummy import Pool as ThreadPool
+
+
+def process_F1file(args):
+    try:
+        file, idx, max = args
+        mess ="{}/{} Procesing F1 '{}'".format(idx, max, file)
+        print mess
+        logging.info(mess)
+
+        importer = F1Importer(file_to_import=file, collection=COLLECTION)
+
+        importer.process_consumptions()
+        os.rename(file, file+"_done")
+
+    except:
+        mess = "Error processing F1 {}.\n{}".format(file)
+        print mess
+        logging.info(mess)
+
+
+def process_Q1file(args):
+    try:
+        file, idx, max = args
+        mess ="{}/{} Procesing q1 '{}'".format(idx, max, file)
+        print mess
+        logging.info(mess)
+
+        importer = Q1Importer(file_to_import=file, collection=COLLECTION)
+        importer.process_consumptions()
+        os.rename(file, file+"_done")
+
+    except:
+        mess = "Error processing Q1 {}.\n{}".format(file)
+        print mess
+        logging.info(mess)
+        pass
+
+
+
+
+def Import_Massive(path_="/opt/srcs/f1/F101", type="F1", CPUs=4):
+
+    os.chdir(path_)
+    files = glob.glob("*.xml")
+    max = len(files)
+
+    pool = ThreadPool(CPUs)
+
+    if (type=="F1"):
+        processer = process_F1file
+    elif (type=="Q1"):
+        processer = process_Q1file
+
+    try:
+        pool.map(processer , ((fileF1, idx, max) for idx, fileF1 in enumerate(files)) )
+    except Exception as e:
+        print "Thread error at processing '{}'".format( e )
+
+    pool.close()
+    pool.join()
+
+
+COLLECTION="rolf"
+
+logging.basicConfig(level=logging.INFO)
+
+#Sampledata_tester()
+#Proposal_tester()
+
+Import_Massive(path_="/opt/srcs/f1/F101", type="F1", CPUs=2)


### PR DESCRIPTION
Improvement over the main import process (for all file types).

oraKWlum's default datastore is Mongo, and Mongo by default just can use one CPU/core for write operations.

An easy way to ensure processor optimization is to start N concurrent threads (with an isolated DB connection).

With this, the import process works in parallel ensuring more efficiency and reach more performance than using the serial way.

The performance must be reviewed, for this dev iteration is enough.

```
Import_Massive(path_="/opt/srcs/f1/F101", type="F1", CPUs=2)
```