### PR TITLE
Bug at consumptions creation

### DIFF
--- a/example.py
+++ b/example.py
@@ -76,8 +76,8 @@ def Prediction_tester():
 
 
 def Proposal_tester():
-    date_start = datetime(2016, 04, 01)
-    date_end = datetime(2016, 04, 30)
+    date_start = datetime(2015, 12, 04)
+    date_end = datetime(2015, 12, 05)
 
     cups_to_filter = None
 
@@ -85,7 +85,7 @@ def Proposal_tester():
                         end_date=date_end,
                         filter_cups=cups_to_filter,
                         compute=True,
-                        collection="dataset")
+                        collection=COLLECTION)
 
     proposal.add_new_scenario(name="Original projection",
                               type="base",
@@ -148,9 +148,9 @@ def Import_testerLiteQ1():
     importer.process_consumptions()
 
 
-COLLECTION = "rolf"
+COLLECTION = "importer_test2"
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 
 #Sampledata_tester()
-#Proposal_tester()
+Proposal_tester()

--- a/orakwlum/consumption/consumption.py
+++ b/orakwlum/consumption/consumption.py
@@ -61,8 +61,8 @@ class Consumption(object):
             print "Hour is not propertly defined:", type_hour
             raise
 
-        assert origin in self.SOURCE_PRIORITY, "Origin '{}' not knowed...\n origins: '{}'".format(
-            origin, self.SOURCE_PRIORITY)
+        assert origin in self.SOURCE_PRIORITY, "Origin '{}' not knowed...\n origins: '{}'\n line: {}".format(
+            origin, self.SOURCE_PRIORITY, cups)
 
         self.consumption_real = real
         self.consumption_proposal = proposal

--- a/orakwlum/consumption/consumption.py
+++ b/orakwlum/consumption/consumption.py
@@ -37,7 +37,16 @@ class Consumption(object):
                  origin,
                  real=None,
                  proposal=None,
-                 time_disc=None):
+                 time_disc=None,
+                 province=None,
+                 ZIP=None,
+                 voltage=None,
+                 distributor=None,
+                 origin_priority=None,
+                 tariff=None,
+                 pom_type=None,
+                 ):
+
         logger.debug('Creating new consumption')
         assert cups, "CUPS is needed to create a Consumption"
         assert hour, "hour is mandatory to create a Consumption"
@@ -72,12 +81,12 @@ class Consumption(object):
         self.origin_priority = self.set_origin_priority(self.origin)
 
         # Static info
-        self.tariff = None
-        self.ZIP = None
-        self.province = None
-        self.voltage = None
-        self.pom_type = None
-        self.distributor = None
+        self.tariff = tariff
+        self.ZIP = ZIP
+        self.province = province
+        self.voltage = voltage
+        self.pom_type = pom_type
+        self.distributor = distributor
         self.time_disc = time_disc
 
         logger.debug(

--- a/orakwlum/consumption/history.py
+++ b/orakwlum/consumption/history.py
@@ -206,8 +206,15 @@ class History(object):
                            origin=JSON['origin'],
                            real=JSON['consumption_real'],
                            proposal=JSON['consumption_proposal'],
-                           time_disc=JSON['time_disc'])
-
+                           time_disc=JSON['time_disc'],
+                           province=JSON['province'],
+                           ZIP=JSON['ZIP'],
+                           voltage=JSON['voltage'],
+                           distributor=JSON['distributor'],
+                           origin_priority=JSON['origin_priority'],
+                           tariff=JSON['tariff'],
+                           pom_type=JSON['pom_type'],
+                           )
 
     def consumption_from_JSON(self, JSON):
         """

--- a/orakwlum/consumption/history.py
+++ b/orakwlum/consumption/history.py
@@ -201,9 +201,13 @@ class History(object):
         """
         # Ensure object type at DB
         #if '__type__' in obj and obj['__type__'] == 'Consumption':
-        return Consumption(JSON['cups'], JSON['hour'],
-                           JSON['consumption_real'],
-                           JSON['consumption_proposal'])
+        return Consumption(cups=JSON['cups'],
+                           hour=JSON['hour'],
+                           origin=JSON['origin'],
+                           real=JSON['consumption_real'],
+                           proposal=JSON['consumption_proposal'],
+                           time_disc=JSON['time_disc'])
+
 
     def consumption_from_JSON(self, JSON):
         """

--- a/utils/importer.py
+++ b/utils/importer.py
@@ -47,7 +47,8 @@ logging.basicConfig(
     filename='../oraKWlum.log',
     filemode='a')
 
-#Import_Massive(path_="../inputs/F1", filter="*.xml", type="F1", CPUs=2)
+Import_Massive(path_="../inputs/F1", filter="*.xml", type="F1", CPUs=2)
 #Import_Massive(path_="../inputs/Q1", filter="*.xml", type="Q1", CPUs=2)
 #Import_Massive(path_="../inputs/P5D", filter="*0*", type="P5D", CPUs=2)
-Import_Massive(path_="../inputs/F5D", filter="*0*", type="F5D", CPUs=2)
+#Import_Massive(path_="../inputs/F5D", filter="*0*", type="F5D", CPUs=2)
+


### PR DESCRIPTION
Solving a bug at global Consumption creation.

Consumption doesn't reach the expected origin property, so the assertion that confirms that the origin is valid (F5D, F1, P5D, Q1) raise an exception.

Additionally, in order to avoid future incidents all the "static data" related to a Consumption is properly initialized. Also the consumption_decoder method
